### PR TITLE
Increase hash opcode costs in TEAL v2

### DIFF
--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -291,7 +291,7 @@ func TestBackwardCompatTEALv1(t *testing.T) {
 	cost2, err := Check(program2, ep)
 	require.NoError(t, err)
 
-	// Costs for the v2 should be higher because of hash opcode changes
+	// Costs for v2 should be higher because of hash opcode cost changes
 	require.Equal(t, 2308, cost2)
 	pass, err = Eval(program2, ep)
 	if err != nil || !pass {

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -290,7 +290,9 @@ func TestBackwardCompatTEALv1(t *testing.T) {
 
 	cost2, err := Check(program2, ep)
 	require.NoError(t, err)
-	require.Equal(t, 2140, cost2)
+
+	// Costs for the v2 should be higher because of hash opcode changes
+	require.Equal(t, 2308, cost2)
 	pass, err = Eval(program2, ep)
 	if err != nil || !pass {
 		t.Log(hex.EncodeToString(program2))

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -64,6 +64,15 @@ var OpSpecs = []OpSpec{
 	{0x01, "sha256", opSHA256, asmDefault, disDefault, oneBytes, oneBytes, 1, modeAny, opSize{7, 1, nil}},
 	{0x02, "keccak256", opKeccak256, asmDefault, disDefault, oneBytes, oneBytes, 1, modeAny, opSize{26, 1, nil}},
 	{0x03, "sha512_256", opSHA512_256, asmDefault, disDefault, oneBytes, oneBytes, 1, modeAny, opSize{9, 1, nil}},
+
+	// Cost of these opcodes increases in TEAL version 2 based on measured
+	// performance. Should be able to run max hashes during stateful TEAL
+	// and achieve reasonable TPS. Same opcode for different TEAL versions
+	// is OK.
+	{0x01, "sha256", opSHA256, asmDefault, disDefault, oneBytes, oneBytes, 2, modeAny, opSize{35, 1, nil}},
+	{0x02, "keccak256", opKeccak256, asmDefault, disDefault, oneBytes, oneBytes, 2, modeAny, opSize{130, 1, nil}},
+	{0x03, "sha512_256", opSHA512_256, asmDefault, disDefault, oneBytes, oneBytes, 2, modeAny, opSize{45, 1, nil}},
+
 	{0x04, "ed25519verify", opEd25519verify, asmDefault, disDefault, threeBytes, oneInt, 1, runModeSignature, opSize{1900, 1, nil}},
 	{0x08, "+", opPlus, asmDefault, disDefault, twoInts, oneInt, 1, modeAny, opSizeDefault},
 	{0x09, "-", opMinus, asmDefault, disDefault, twoInts, oneInt, 1, modeAny, opSizeDefault},


### PR DESCRIPTION
Increasing based off of pingpong performance results for the different hash types.