### PR TITLE
TEAL: dup2 + string literals

### DIFF
--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -295,13 +295,15 @@ byte b32 AAAA...
 byte base32(AAAA...)
 byte b32(AAAA...)
 byte 0x0123456789abcdef...
+byte "\x01\x02"
+byte "string literal"
 ```
 
 `int` constants may be `0x` prefixed for hex, `0` prefixed for octal, or decimal numbers.
 
 `intcblock` may be explictly assembled. It will conflict with the assembler gathering `int` pseudo-ops into a `intcblock` program prefix, but may be used if code only has explicit `intc` references. `intcblock` should be followed by space separated int constants all on one line.
 
-`bytecblock` may be explicitly assembled. It will conflict with the assembler if there are any `byte` pseudo-ops but may be used if only explicit `bytec` references are used. `bytecblock` should be followed with byte constants all on one line, either 'encoding value' pairs (`b64 AAA...`) or 0x prefix or function-style values (`base64(...)`).
+`bytecblock` may be explicitly assembled. It will conflict with the assembler if there are any `byte` pseudo-ops but may be used if only explicit `bytec` references are used. `bytecblock` should be followed with byte constants all on one line, either 'encoding value' pairs (`b64 AAA...`) or 0x prefix or function-style values (`base64(...)`) or string literal values.
 
 ## Labels and Branches
 

--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -255,6 +255,7 @@ Asset fields include `AssetHolding` and `AssetParam` fields that are used in `as
 | `return` | use last value on stack as success value; end |
 | `pop` | discard value X from stack |
 | `dup` | duplicate last value on stack |
+| `dup2` | duplicate two last values on stack: A, B -> A, B, A, B |
 
 ### State Access
 

--- a/data/transactions/logic/README_in.md
+++ b/data/transactions/logic/README_in.md
@@ -138,13 +138,15 @@ byte b32 AAAA...
 byte base32(AAAA...)
 byte b32(AAAA...)
 byte 0x0123456789abcdef...
+byte "\x01\x02"
+byte "string literal"
 ```
 
 `int` constants may be `0x` prefixed for hex, `0` prefixed for octal, or decimal numbers.
 
 `intcblock` may be explictly assembled. It will conflict with the assembler gathering `int` pseudo-ops into a `intcblock` program prefix, but may be used if code only has explicit `intc` references. `intcblock` should be followed by space separated int constants all on one line.
 
-`bytecblock` may be explicitly assembled. It will conflict with the assembler if there are any `byte` pseudo-ops but may be used if only explicit `bytec` references are used. `bytecblock` should be followed with byte constants all on one line, either 'encoding value' pairs (`b64 AAA...`) or 0x prefix or function-style values (`base64(...)`).
+`bytecblock` may be explicitly assembled. It will conflict with the assembler if there are any `byte` pseudo-ops but may be used if only explicit `bytec` references are used. `bytecblock` should be followed with byte constants all on one line, either 'encoding value' pairs (`b64 AAA...`) or 0x prefix or function-style values (`base64(...)`) or string literal values.
 
 ## Labels and Branches
 

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -509,6 +509,14 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 - Pushes: any, any
 - duplicate last value on stack
 
+## dup2
+
+- Opcode: 0x4a
+- Pops: *... stack*, {any A}, {any B}
+- Pushes: any, any, any, any
+- duplicate two last values on stack: A, B -> A, B, A, B
+- LogicSigVersion >= 2
+
 ## concat
 
 - Opcode: 0x50

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -432,6 +432,9 @@ func parseBinaryArgs(args []string) (val []byte, consumed int, err error) {
 			return
 		}
 		consumed = 2
+	} else if len(arg) > 2 && arg[0] == '"' && arg[len(arg)-1] == '"' {
+		val, err = parseStringLiteral(arg)
+		consumed = 1
 	} else {
 		err = fmt.Errorf("byte arg did not parse: %v", arg)
 		return
@@ -439,9 +442,78 @@ func parseBinaryArgs(args []string) (val []byte, consumed int, err error) {
 	return
 }
 
+func parseStringLiteral(input string) (result []byte, err error) {
+	start := 0
+	end := len(input) - 1
+	if input[start] != '"' || input[end] != '"' {
+		return nil, fmt.Errorf("no quotes")
+	}
+	start++
+
+	escapeSeq := false
+	hexSeq := false
+	result = make([]byte, 0, end-start+1)
+
+	// skip first and last quotes
+	pos := start
+	for pos < end {
+		char := input[pos]
+		if char == '\\' && !escapeSeq {
+			if hexSeq {
+				return nil, fmt.Errorf("escape seq inside hex number")
+			}
+			escapeSeq = true
+			pos++
+			continue
+		}
+		if escapeSeq {
+			escapeSeq = false
+			switch char {
+			case 'n':
+				char = '\n'
+			case 'r':
+				char = '\r'
+			case 't':
+				char = '\t'
+			case '\\':
+				char = '\\'
+			case '"':
+				char = '"'
+			case 'x':
+				hexSeq = true
+				pos++
+				continue
+			default:
+				return nil, fmt.Errorf("invalid escape seq \\%c", char)
+			}
+		}
+		if hexSeq {
+			hexSeq = false
+			if pos >= len(input)-2 { // count a closing quote
+				return nil, fmt.Errorf("non-terminated hex seq")
+			}
+			num, err := strconv.ParseUint(input[pos:pos+2], 16, 8)
+			if err != nil {
+				return nil, err
+			}
+			char = uint8(num)
+			pos++
+		}
+
+		result = append(result, char)
+		pos++
+	}
+	if escapeSeq || hexSeq {
+		return nil, fmt.Errorf("non-terminated escape seq")
+	}
+
+	return
+}
+
 // byte {base64,b64,base32,b32}(...)
 // byte {base64,b64,base32,b32} ...
 // byte 0x....
+// byte "this is a string\n"
 func assembleByte(ops *OpStream, spec *OpSpec, args []string) error {
 	var val []byte
 	var err error

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -38,11 +38,6 @@ byte base64(aGVsbG8gd29ybGQh)
 byte b64 aGVsbG8gd29ybGQh
 byte b64(aGVsbG8gd29ybGQh)
 addr RWXCBB73XJITATVQFOI7MVUUQOL2PFDDSDUMW4H4T2SNSX4SEUOQ2MM7F4
-concat
-substring 42 99
-intc 0
-intc 1
-substring3
 ed25519verify
 txn Sender
 txn Fee
@@ -122,8 +117,6 @@ intc 1
 %
 ^
 ~
-bz there
-b there
 byte 0x4242
 btoi
 itob
@@ -139,7 +132,21 @@ store 2
 intc 0
 intc 1
 mulw
-pop  // pop extra returned element to balance the stack
+dup2
+pop
+pop
+pop
+pop
+addr RWXCBB73XJITATVQFOI7MVUUQOL2PFDDSDUMW4H4T2SNSX4SEUOQ2MM7F4
+concat
+substring 42 99
+intc 0
+intc 1
+substring3
+bz there2
+b there2
+there2:
+return
 int 1
 balance
 int 1
@@ -210,7 +217,7 @@ func TestAssemble(t *testing.T) {
 	program, err := AssembleString(bigTestAssembleNonsenseProgram)
 	require.NoError(t, err)
 	// check that compilation is stable over time and we assemble to the same bytes this month that we did last month.
-	expectedBytes, _ := hex.DecodeString("022008b7a60cf8acd19181cf959a12f8acd19181cf951af8acd19181cf15f8acd191810f01020026040212340c68656c6c6f20776f726c6421208dae2087fbba51304eb02b91f656948397a7946390e8cb70fc9ea4d95f92251d02424200320032013202320328292929292a50512a632223520431003101310231043105310731083109310a310b310c310d310e310f311131123113311431153118311933000033000133000233000433000533000733000833000933000a33000b33000c33000d33000e33000f3300113300123300133300143300152d2e0102222324252104082209240a220b230c240d250e230f23102311231223132314181b1c41000d42000a2b171615400003290349483403350222231d4821056021056121052b63484821052b62482b642b65484821052b2106662b21056721072b682b6921072105700048482107210571004848361c004837001a0048")
+	expectedBytes, _ := hex.DecodeString("022008b7a60cf8acd19181cf959a12f8acd19181cf951af8acd19181cf15f8acd191810f01020026040212340c68656c6c6f20776f726c6421208dae2087fbba51304eb02b91f656948397a7946390e8cb70fc9ea4d95f92251d02424200320032013202320328292929292a0431003101310231043105310731083109310a310b310c310d310e310f311131123113311431153118311933000033000133000233000433000533000733000833000933000a33000b33000c33000d33000e33000f3300113300123300133300143300152d2e0102222324252104082209240a220b230c240d250e230f23102311231223132314181b1c2b171615400003290349483403350222231d4a484848482a50512a632223524100034200004321056021056121052b63484821052b62482b642b65484821052b2106662b21056721072b682b6921072105700048482107210571004848361c004837001a0048")
 	if bytes.Compare(expectedBytes, program) != 0 {
 		// this print is for convenience if the program has been changed. the hex string can be copy pasted back in as a new expected result.
 		t.Log(hex.EncodeToString(program))
@@ -617,12 +624,12 @@ func TestAssembleDisassembleCycle(t *testing.T) {
 
 	tests := map[uint64]string{
 		2: bigTestAssembleNonsenseProgram,
-		1: bigTestAssembleNonsenseProgram[:strings.Index(bigTestAssembleNonsenseProgram, "balance")],
+		1: bigTestAssembleNonsenseProgram[:strings.Index(bigTestAssembleNonsenseProgram, "dup2")],
 	}
 
 	for v, source := range tests {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleString(source)
+			program, err := AssembleStringWithVersion(source, v)
 			require.NoError(t, err)
 			t2, err := Disassemble(program)
 			require.NoError(t, err)
@@ -631,7 +638,7 @@ func TestAssembleDisassembleCycle(t *testing.T) {
 				t.Log(t2)
 			}
 			require.NoError(t, err)
-			require.Equal(t, program, p2)
+			require.Equal(t, program[1:], p2[1:])
 		})
 	}
 }

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -93,6 +93,7 @@ var opDocList = []stringString{
 	{"return", "use last value on stack as success value; end"},
 	{"pop", "discard value X from stack"},
 	{"dup", "duplicate last value on stack"},
+	{"dup2", "duplicate two last values on stack: A, B -> A, B, A, B"},
 	{"concat", "pop two byte strings A and B and join them, push the result"},
 	{"substring", "pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result"},
 	{"substring3", "pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result"},
@@ -197,7 +198,7 @@ type OpGroup struct {
 var OpGroupList = []OpGroup{
 	{"Arithmetic", []string{"sha256", "keccak256", "sha512_256", "ed25519verify", "+", "-", "/", "*", "<", ">", "<=", ">=", "&&", "||", "==", "!=", "!", "len", "itob", "btoi", "%", "|", "&", "^", "~", "mulw", "concat", "substring", "substring3"}},
 	{"Loading Values", []string{"intcblock", "intc", "intc_0", "intc_1", "intc_2", "intc_3", "bytecblock", "bytec", "bytec_0", "bytec_1", "bytec_2", "bytec_3", "arg", "arg_0", "arg_1", "arg_2", "arg_3", "txn", "gtxn", "txna", "gtxna", "global", "load", "store"}},
-	{"Flow Control", []string{"err", "bnz", "bz", "b", "return", "pop", "dup"}},
+	{"Flow Control", []string{"err", "bnz", "bz", "b", "return", "pop", "dup", "dup2"}},
 	{"State Access", []string{"balance", "app_opted_in", "app_local_gets", "app_local_get", "app_global_gets", "app_global_get", "app_local_put", "app_global_put", "app_local_del", "app_global_del", "asset_holding_get", "asset_params_get"}},
 }
 

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -573,6 +573,10 @@ func (cx *evalContext) step() {
 			if len(spec.Returns) > 1 {
 				num = len(spec.Returns)
 			}
+			if len(cx.stack) < num {
+				cx.err = fmt.Errorf("stack underflow: expected %d, have %d", num, len(cx.stack))
+				return
+			}
 			for i := 1; i <= num; i++ {
 				stackString += fmt.Sprintf("(%s) ", cx.stack[len(cx.stack)-i].String())
 			}
@@ -1117,6 +1121,12 @@ func opDup(cx *evalContext) {
 	last := len(cx.stack) - 1
 	sv := cx.stack[last]
 	cx.stack = append(cx.stack, sv)
+}
+
+func opDup2(cx *evalContext) {
+	last := len(cx.stack) - 1
+	prev := last - 1
+	cx.stack = append(cx.stack, cx.stack[prev:]...)
 }
 
 func (cx *evalContext) assetHoldingEnumToValue(holding *basics.AssetHolding, field uint64) (sv stackValue, err error) {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -2383,7 +2383,7 @@ func TestShortBytecblock(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerDefaultVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			fullprogram, err := AssembleStringWithVersion(`bytecblock 0x123456 0xababcdcd`, v)
+			fullprogram, err := AssembleStringWithVersion(`bytecblock 0x123456 0xababcdcd "test"`, v)
 			require.NoError(t, err)
 			fullprogram[2] = 50 // fake 50 elements
 			for i := 2; i < len(fullprogram); i++ {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3210,3 +3210,56 @@ intc_0
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "stack overflow")
 }
+
+func TestDup(t *testing.T) {
+	t.Parallel()
+
+	text := `int 1
+dup
+==
+bnz dup_ok
+err
+dup_ok:
+int 1
+int 2
+dup2 // expected 1, 2, 1, 2
+int 2
+==
+bz error
+int 1
+==
+bz error
+int 2
+==
+bz error
+int 1
+==
+bz error
+b exit
+error:
+err
+exit:
+int 1
+`
+	ep := defaultEvalParams(nil, nil)
+
+	program, err := AssembleString(text)
+	require.NoError(t, err)
+	pass, err := Eval(program, ep)
+	require.NoError(t, err)
+	require.True(t, pass)
+
+	text = `dup2`
+	program, err = AssembleString(text)
+	require.NoError(t, err)
+	pass, err = Eval(program, ep)
+	require.Error(t, err)
+
+	text = `int 1
+dup2
+`
+	program, err = AssembleString(text)
+	require.NoError(t, err)
+	pass, err = Eval(program, ep)
+	require.Error(t, err)
+}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3263,3 +3263,29 @@ dup2
 	pass, err = Eval(program, ep)
 	require.Error(t, err)
 }
+
+func TestStringLiteral(t *testing.T) {
+	t.Parallel()
+
+	text := `byte "foo bar"
+byte b64(Zm9vIGJhcg==)
+==
+`
+	ep := defaultEvalParams(nil, nil)
+
+	program, err := AssembleString(text)
+	require.NoError(t, err)
+	pass, err := Eval(program, ep)
+	require.NoError(t, err)
+	require.True(t, pass)
+
+	text = `byte "foo bar // not a comment"
+byte b64(Zm9vIGJhciAvLyBub3QgYSBjb21tZW50)
+==
+`
+	program, err = AssembleString(text)
+	require.NoError(t, err)
+	pass, err = Eval(program, ep)
+	require.NoError(t, err)
+	require.True(t, pass)
+}

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -135,6 +135,8 @@ var OpSpecs = []OpSpec{
 	{0x43, "return", opReturn, asmDefault, disDefault, oneInt, nil, 2, modeAny, opSizeDefault},
 	{0x48, "pop", opPop, asmDefault, disDefault, oneAny, nil, 1, modeAny, opSizeDefault},
 	{0x49, "dup", opDup, asmDefault, disDefault, oneAny, twoAny, 1, modeAny, opSizeDefault},
+	{0x4a, "dup2", opDup2, asmDefault, disDefault, twoAny, twoAny.plus(twoAny), 2, modeAny, opSizeDefault},
+
 	{0x50, "concat", opConcat, asmDefault, disDefault, twoBytes, oneBytes, 2, modeAny, opSizeDefault},
 	{0x51, "substring", opSubstring, assembleSubstring, disSubstring, oneBytes, oneBytes, 2, modeAny, opSize{1, 3, nil}},
 	{0x52, "substring3", opSubstring3, asmDefault, disDefault, byteIntInt, oneBytes, 2, modeAny, opSizeDefault},


### PR DESCRIPTION
`dup2` is useful in read+write sequence of local state changes (saves up to 3 bytes)
`byte "string literal\n\x13"` is simply nice to have