### PR TITLE
Error if `global Round` called with nil ledger

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1415,11 +1415,7 @@ func (cx *evalContext) globalFieldToStack(field GlobalField) (sv stackValue, err
 	case LogicSigVersion:
 		sv.Uint = cx.Proto.LogicSigVersion
 	case Round:
-		if (cx.runModeFlags & runModeApplication) == 0 {
-			sv.Uint = 0
-		} else {
-			sv.Uint, err = cx.getRound()
-		}
+		sv.Uint, err = cx.getRound()
 	default:
 		err = fmt.Errorf("invalid global[%d]", field)
 	}

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1415,7 +1415,11 @@ func (cx *evalContext) globalFieldToStack(field GlobalField) (sv stackValue, err
 	case LogicSigVersion:
 		sv.Uint = cx.Proto.LogicSigVersion
 	case Round:
-		sv.Uint, err = cx.getRound()
+		if (cx.runModeFlags & runModeApplication) == 0 {
+			err = errors.New("global Round not allowed in current mode")
+		} else {
+			sv.Uint, err = cx.getRound()
+		}
 	default:
 		err = fmt.Errorf("invalid global[%d]", field)
 	}

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -2498,11 +2498,9 @@ int 1
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ledger not available")
 
-	// TODO this should fail not just because ledger is not available, but
-	// also because it is in stateless mode.
 	pass, err := Eval(program, ep)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "ledger not available")
+	require.Contains(t, err.Error(), "not allowed in current mode")
 
 	ep.Ledger = ledger
 	pass, _, err = EvalStateful(program, ep)

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -2498,12 +2498,14 @@ int 1
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ledger not available")
 
+	// TODO this should fail not just because ledger is not available, but
+	// also because it is in stateless mode.
+	pass, err := Eval(program, ep)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ledger not available")
+
 	ep.Ledger = ledger
-	pass, _, err := EvalStateful(program, ep)
+	pass, _, err = EvalStateful(program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
-
-	pass, err = Eval(program, ep)
-	require.NoError(t, err)
-	require.False(t, pass)
 }

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -1101,7 +1101,7 @@ txn CloseRemainderTo
 //int 2069
 //==
 //&&
-//global Round
+//global Round // Tested in TestRound
 //int 999999
 //==
 &&
@@ -1111,10 +1111,6 @@ int 1
 &&
 global LogicSigVersion // TODO: stricter checking on field vs version
 int 2
-==
-&&
-global Round
-int 0
 ==
 &&`
 


### PR DESCRIPTION
We should make it so that there are no tests relying on calling `Eval` with a non-nil Ledger or `EvalStateful` with a nil ledger, and then we can just add a check in `eval` to ensure the nilness matches the runmode.