### PR TITLE
Fix stale state bug

### DIFF
--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -835,6 +835,28 @@ int 0
 	pass, _, err = EvalStateful(program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
+
+	text = `
+byte 0x41414141
+int 4141
+app_global_put
+int 100
+byte 0x41414141
+app_global_get
+int 4141
+==
+pop
+`
+	// check that even during application creation (Txn.ApplicationID == 0)
+	// we will use the the kvCow if the exact application ID (100) is
+	// specified in the transcation
+	program, err = AssembleString(text)
+	require.NoError(t, err)
+
+	ep.Txn.Txn.ApplicationID = 0
+	pass, _, err = EvalStateful(program, ep)
+	require.NoError(t, err)
+	require.True(t, pass)
 }
 
 const assetsTestProgram = `int 0

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -170,6 +170,10 @@ func (l *testLedger) AssetParams(addr basics.Address, assetID basics.AssetIndex)
 	return basics.AssetParams{}, fmt.Errorf("no such address")
 }
 
+func (l *testLedger) ApplicationID() basics.AppIndex {
+	return basics.AppIndex(l.appID)
+}
+
 func TestEvalModes(t *testing.T) {
 	t.Parallel()
 	// ed25519verify and err are tested separately below

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -849,7 +849,7 @@ pop
 `
 	// check that even during application creation (Txn.ApplicationID == 0)
 	// we will use the the kvCow if the exact application ID (100) is
-	// specified in the transcation
+	// specified in the transaction
 	program, err = AssembleString(text)
 	require.NoError(t, err)
 

--- a/ledger/applications.go
+++ b/ledger/applications.go
@@ -83,7 +83,6 @@ func (ae *appTealEvaluator) InitLedger(balances transactions.Balances, acctWhite
 	}
 
 	ae.evalParams.Ledger = ledger
-	ae.evalParams.AppID = appIdx
 	return nil
 }
 
@@ -279,4 +278,8 @@ func (al *appLedger) Round() basics.Round {
 
 func (al *appLedger) LatestTimestamp() int64 {
 	return al.AppTealGlobals.LatestTimestamp
+}
+
+func (al *appLedger) ApplicationID() basics.AppIndex {
+	return al.appIdx
 }

--- a/ledger/applications.go
+++ b/ledger/applications.go
@@ -83,6 +83,7 @@ func (ae *appTealEvaluator) InitLedger(balances transactions.Balances, acctWhite
 	}
 
 	ae.evalParams.Ledger = ledger
+	ae.evalParams.AppID = appIdx
 	return nil
 }
 


### PR DESCRIPTION
We would incorrectly return stale state if the user manually specified the app ID of the application being created by this transaction.