### PR TITLE
Use correct txn in group context

### DIFF
--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -500,7 +500,7 @@ func (eval *BlockEvaluator) prepareAppEvaluators(txgroup []transactions.SignedTx
 		// transactions.StateEvaluator) for use in ApplicationCall transactions.
 		steva := appTealEvaluator{
 			evalParams: logic.EvalParams{
-				Txn:        &txn.SignedTxn,
+				Txn:        &groupNoAD[i],
 				Proto:      &eval.proto,
 				TxnGroup:   groupNoAD,
 				GroupIndex: i,


### PR DESCRIPTION
This fixes a critical bug where the stateful eval context referred to the wrong transaction.