### PR TITLE
Avoid additional ledger lookup on clear state if app deleted

### DIFF
--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -542,13 +542,13 @@ func (ac *ApplicationCallTxnFields) applyClearState(
 		} else {
 			// Ignore errors and rejections from the ClearStateProgram
 		}
-	}
 
-	// Fetch the (potentially updated) sender record
-	record, err = balances.Get(sender, false)
-	if err != nil {
-		ad.EvalDelta = basics.EvalDelta{}
-		return err
+		// Fetch the (potentially updated) sender record
+		record, err = balances.Get(sender, false)
+		if err != nil {
+			ad.EvalDelta = basics.EvalDelta{}
+			return err
+		}
 	}
 
 	// Update the TotalAppSchema used for MinBalance calculation,


### PR DESCRIPTION
addresses some feedback from https://github.com/algorand/go-algorand/pull/1138

I think this is OK, because the record should only be updated in the event that the clear state program exists.