### PR TITLE
Rename some applications methods, move clearing `EvalDelta` to a defer

### DIFF
--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -288,10 +288,12 @@ func (ac *ApplicationCallTxnFields) applyEvalDelta(evalDelta basics.EvalDelta, p
 			return fmt.Errorf("duplicate LocalState delta for %s", addr.String())
 		}
 
-		// Skip over empty deltas, because we shouldn't fail because of
-		// a zero-delta on an account that hasn't opted in
+		// Zero-length deltas are not allowed. We should never produce them from Eval.
 		if len(delta) == 0 {
-			continue
+			if !errIfNotApplied {
+				return nil
+			}
+			return fmt.Errorf("got zero-length delta for %s, not allowed", addr.String())
 		}
 
 		// Check that the local state delta isn't breaking any rules regarding

--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -180,7 +180,7 @@ func getAppParams(balances Balances, aidx basics.AppIndex) (params basics.AppPar
 	return
 }
 
-func applyDelta(kv basics.TealKeyValue, stateDelta basics.StateDelta) error {
+func applyStateDelta(kv basics.TealKeyValue, stateDelta basics.StateDelta) error {
 	if kv == nil {
 		return fmt.Errorf("cannot apply delta to nil TealKeyValue")
 	}
@@ -209,10 +209,18 @@ func applyDelta(kv basics.TealKeyValue, stateDelta basics.StateDelta) error {
 	return nil
 }
 
-// applyStateDeltas applies a basics.EvalDelta to the app's global key/value
+// applyEvalDelta applies a basics.EvalDelta to the app's global key/value
 // store as well as a set of local key/value stores. If this function returns
 // an error, the transaction must not be committed.
-func (ac *ApplicationCallTxnFields) applyStateDeltas(evalDelta basics.EvalDelta, params basics.AppParams, creator, sender basics.Address, balances Balances, appIdx basics.AppIndex, errIfNotApplied bool) error {
+//
+// The errIfNotApplied parameter is set to false when applying the results of a
+// ClearState program. ClearState programs are not allowed to reject
+// transactions for any reason. So if the ClearState program passes,
+// but returns an invalid evalDelta that we cannot apply (e.g. because it would
+// violate a schema), then errIfNotApplied = false instructs applyEvalDelta to
+// return a nil error. For system errors (e.g. failing to fetch or write a
+// balance record), applyEvalDelta will always return a non-nil error.
+func (ac *ApplicationCallTxnFields) applyEvalDelta(evalDelta basics.EvalDelta, params basics.AppParams, creator, sender basics.Address, balances Balances, appIdx basics.AppIndex, errIfNotApplied bool) error {
 	/*
 	 * 1. Apply GlobalState delta (if any), allocating the key/value store
 	 *    if required.
@@ -240,7 +248,7 @@ func (ac *ApplicationCallTxnFields) applyStateDeltas(evalDelta basics.EvalDelta,
 		}
 
 		// Apply the GlobalDelta in place on the cloned copy
-		err = applyDelta(params.GlobalState, evalDelta.GlobalDelta)
+		err = applyStateDelta(params.GlobalState, evalDelta.GlobalDelta)
 		if err != nil {
 			return err
 		}
@@ -317,7 +325,7 @@ func (ac *ApplicationCallTxnFields) applyStateDeltas(evalDelta basics.EvalDelta,
 			localState.KeyValue = make(basics.TealKeyValue)
 		}
 
-		err = applyDelta(localState.KeyValue, delta)
+		err = applyStateDelta(localState.KeyValue, delta)
 		if err != nil {
 			return err
 		}
@@ -482,7 +490,6 @@ func (ac *ApplicationCallTxnFields) applyClearState(
 	balances Balances, sender basics.Address, appIdx basics.AppIndex,
 	ad *ApplyData, steva StateEvaluator,
 ) error {
-
 	// Fetch the application parameters, if they exist
 	params, creator, exists, err := getAppParams(balances, appIdx)
 	if err != nil {
@@ -506,14 +513,14 @@ func (ac *ApplicationCallTxnFields) applyClearState(
 		// Execute the ClearStateProgram before we've deleted the LocalState
 		// for this account. If the ClearStateProgram does not fail, apply any
 		// state deltas it generated.
-		pass, stateDeltas, err := steva.Eval(params.ClearStateProgram)
+		pass, evalDelta, err := steva.Eval(params.ClearStateProgram)
 		if err == nil && pass {
 			// Program execution may produce some GlobalState and LocalState
 			// deltas. Apply them, provided they don't exceed the bounds set by
 			// the GlobalStateSchema and LocalStateSchema. If they do exceed
 			// those bounds, then don't fail, but also don't apply the changes.
 			failIfNotApplied := false
-			err = ac.applyStateDeltas(stateDeltas, params, creator, sender,
+			err = ac.applyEvalDelta(evalDelta, params, creator, sender,
 				balances, appIdx, failIfNotApplied)
 			if err != nil {
 				return err
@@ -521,7 +528,7 @@ func (ac *ApplicationCallTxnFields) applyClearState(
 
 			// Fill in applyData, so that consumers don't have to implement a
 			// stateful TEAL interpreter to apply state changes
-			ad.EvalDelta = stateDeltas
+			ad.EvalDelta = evalDelta
 		} else {
 			// Ignore errors and rejections from the ClearStateProgram
 		}
@@ -545,11 +552,7 @@ func (ac *ApplicationCallTxnFields) applyClearState(
 	record.AppLocalStates = cloneAppLocalStates(record.AppLocalStates)
 	delete(record.AppLocalStates, appIdx)
 
-	err = balances.Put(record)
-	if err != nil {
-		ad.EvalDelta = basics.EvalDelta{}
-	}
-	return err
+	return balances.Put(record)
 }
 
 func applyOptIn(balances Balances, sender basics.Address, appIdx basics.AppIndex, params basics.AppParams) error {
@@ -586,6 +589,14 @@ func applyOptIn(balances Balances, sender basics.Address, appIdx basics.AppIndex
 }
 
 func (ac *ApplicationCallTxnFields) apply(header Header, balances Balances, spec SpecialAddresses, ad *ApplyData, txnCounter uint64, steva StateEvaluator) (err error) {
+	defer func() {
+		// If we are returning a non-nil error, then don't return a
+		// non-empty EvalDelta. Not required for correctness.
+		if err != nil && ad != nil {
+			ad.EvalDelta = basics.EvalDelta{}
+		}
+	}()
+
 	// Keep track of the application ID we're working on
 	appIdx := ac.ApplicationID
 
@@ -658,7 +669,7 @@ func (ac *ApplicationCallTxnFields) apply(header Header, balances Balances, spec
 	}
 
 	// Execute the Approval program
-	approved, stateDeltas, err := steva.Eval(params.ApprovalProgram)
+	approved, evalDelta, err := steva.Eval(params.ApprovalProgram)
 	if err != nil {
 		return err
 	}
@@ -671,7 +682,7 @@ func (ac *ApplicationCallTxnFields) apply(header Header, balances Balances, spec
 	// the bounds set by the GlobalStateSchema and LocalStateSchema.
 	// If they would exceed those bounds, then fail.
 	failIfNotApplied := true
-	err = ac.applyStateDeltas(stateDeltas, params, creator, header.Sender,
+	err = ac.applyEvalDelta(evalDelta, params, creator, header.Sender,
 		balances, appIdx, failIfNotApplied)
 	if err != nil {
 		return err
@@ -770,7 +781,7 @@ func (ac *ApplicationCallTxnFields) apply(header Header, balances Balances, spec
 
 	// Fill in applyData, so that consumers don't have to implement a
 	// stateful TEAL interpreter to apply state changes
-	ad.EvalDelta = stateDeltas
+	ad.EvalDelta = evalDelta
 
 	return nil
 }

--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -277,8 +277,9 @@ func (ac *ApplicationCallTxnFields) applyEvalDelta(evalDelta basics.EvalDelta, p
 			return err
 		}
 
-		// Ensure this is not a duplicate address in case we were
-		// passed an invalid EvalDelta
+		// Ensure we did not already receive a non-empty LocalState
+		// delta for this address, in case the caller passed us an
+		// invalid EvalDelta
 		_, ok := changes[addr]
 		if ok {
 			if !errIfNotApplied {

--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -288,7 +288,8 @@ func (ac *ApplicationCallTxnFields) applyEvalDelta(evalDelta basics.EvalDelta, p
 			return fmt.Errorf("duplicate LocalState delta for %s", addr.String())
 		}
 
-		// Zero-length deltas are not allowed. We should never produce them from Eval.
+		// Zero-length LocalState deltas are not allowed. We should never produce
+		// them from Eval.
 		if len(delta) == 0 {
 			if !errIfNotApplied {
 				return nil

--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -27,19 +27,19 @@ const (
 	// number of ApplicationArgs that a transaction decoded off of the wire
 	// can contain. Its value is verified against consensus parameters in
 	// TestEncodedAppTxnAllocationBounds
-	encodedMaxApplicationArgs = 16
+	encodedMaxApplicationArgs = 32
 
 	// encodedMaxAccounts sets the allocation bound for the maximum number
 	// of Accounts that a transaction decoded off of the wire can contain.
 	// Its value is verified against consensus parameters in
 	// TestEncodedAppTxnAllocationBounds
-	encodedMaxAccounts = 4
+	encodedMaxAccounts = 32
 
 	// encodedMaxForeignApps sets the allocation bound for the maximum
 	// number of ForeignApps that a transaction decoded off of the wire can
 	// contain. Its value is verified against consensus parameters in
 	// TestEncodedAppTxnAllocationBounds
-	encodedMaxForeignApps = 2
+	encodedMaxForeignApps = 32
 )
 
 // OnCompletion is an enum representing some layer 1 side effect that an

--- a/data/transactions/application_test.go
+++ b/data/transactions/application_test.go
@@ -614,7 +614,7 @@ func TestAppCallApplyLocalsStateDeltas(t *testing.T) {
 	// empty delta
 	ac.Accounts = append(ac.Accounts, sender, sender)
 	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
-	a.NoError(err)
+	a.Error(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
 

--- a/data/transactions/application_test.go
+++ b/data/transactions/application_test.go
@@ -247,12 +247,12 @@ func TestAppCallApplyDelta(t *testing.T) {
 
 	var tkv basics.TealKeyValue
 	var sd basics.StateDelta
-	err := applyDelta(tkv, sd)
+	err := applyStateDelta(tkv, sd)
 	a.Error(err)
 	a.Contains(err.Error(), "cannot apply delta to nil TealKeyValue")
 
 	tkv = basics.TealKeyValue{}
-	err = applyDelta(tkv, sd)
+	err = applyStateDelta(tkv, sd)
 	a.NoError(err)
 	a.True(len(tkv) == 0)
 
@@ -263,7 +263,7 @@ func TestAppCallApplyDelta(t *testing.T) {
 		},
 	}
 
-	err = applyDelta(tkv, sd)
+	err = applyStateDelta(tkv, sd)
 	a.Error(err)
 	a.Contains(err.Error(), "unknown delta action")
 
@@ -273,7 +273,7 @@ func TestAppCallApplyDelta(t *testing.T) {
 			Uint:   1,
 		},
 	}
-	err = applyDelta(tkv, sd)
+	err = applyStateDelta(tkv, sd)
 	a.NoError(err)
 	a.True(len(tkv) == 1)
 	a.Equal(uint64(1), tkv["test"].Uint)
@@ -284,7 +284,7 @@ func TestAppCallApplyDelta(t *testing.T) {
 			Action: basics.DeleteAction,
 		},
 	}
-	err = applyDelta(tkv, sd)
+	err = applyStateDelta(tkv, sd)
 	a.NoError(err)
 	a.True(len(tkv) == 0)
 
@@ -294,7 +294,7 @@ func TestAppCallApplyDelta(t *testing.T) {
 			Action: basics.SetBytesAction,
 		},
 	}
-	err = applyDelta(tkv, sd)
+	err = applyStateDelta(tkv, sd)
 	a.NoError(err)
 	a.True(len(tkv) == 1)
 	a.Equal(basics.TealBytesType, tkv["test"].Type)
@@ -308,7 +308,7 @@ func TestAppCallApplyDelta(t *testing.T) {
 			Uint:   1,
 		},
 	}
-	err = applyDelta(tkv, sd)
+	err = applyStateDelta(tkv, sd)
 	a.NoError(err)
 	a.True(len(tkv) == 1)
 	a.Equal(basics.TealBytesType, tkv["test"].Type)
@@ -436,13 +436,13 @@ func TestAppCallApplyGlobalStateDeltas(t *testing.T) {
 	var errIfNotApplied = false
 
 	// check empty input
-	err := ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err := ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
 
 	errIfNotApplied = true
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
@@ -453,13 +453,13 @@ func TestAppCallApplyGlobalStateDeltas(t *testing.T) {
 	// check global on unsupported proto
 	b.SetProto(protocol.ConsensusV23)
 	errIfNotApplied = false
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
 
 	errIfNotApplied = true
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 	a.Contains(err.Error(), "cannot apply GlobalState delta")
 	a.Equal(0, b.put)
@@ -468,13 +468,13 @@ func TestAppCallApplyGlobalStateDeltas(t *testing.T) {
 	// check global on supported proto
 	b.SetProto(protocol.ConsensusFuture)
 	errIfNotApplied = false
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
 
 	errIfNotApplied = true
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 	a.Contains(err.Error(), fmt.Sprintf("GlobalState for app %d would use too much space", appIdx))
 	a.Equal(0, b.put)
@@ -483,7 +483,7 @@ func TestAppCallApplyGlobalStateDeltas(t *testing.T) {
 	// check Action=Delete delta on empty params
 	errIfNotApplied = false
 	ed.GlobalDelta["uint"] = basics.ValueDelta{Action: basics.DeleteAction}
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 	a.Contains(err.Error(), "balance not found")
 	a.Equal(0, b.put)
@@ -496,7 +496,7 @@ func TestAppCallApplyGlobalStateDeltas(t *testing.T) {
 	creator = getRandomAddress(a)
 	b.balances = make(map[basics.Address]basics.AccountData)
 	b.balances[creator] = basics.AccountData{}
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(1, b.put)
 	a.Equal(0, b.putWith)
@@ -520,14 +520,14 @@ func TestAppCallApplyGlobalStateDeltas(t *testing.T) {
 	// now check errors with non-default values
 	b.SetProto(protocol.ConsensusV23)
 	ed.GlobalDelta["uint"] = basics.ValueDelta{Action: basics.SetUintAction, Uint: 1}
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
 	a.Equal(basics.AccountData{}, b.balances[creator])
 
 	errIfNotApplied = true
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 	a.Contains(err.Error(), "cannot apply GlobalState delta")
 	a.Equal(0, b.put)
@@ -535,7 +535,7 @@ func TestAppCallApplyGlobalStateDeltas(t *testing.T) {
 	a.Equal(basics.AccountData{}, b.balances[creator])
 
 	b.SetProto(protocol.ConsensusFuture)
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 	a.Contains(err.Error(), fmt.Sprintf("GlobalState for app %d would use too much space: store integer count", appIdx))
 	a.Equal(0, b.put)
@@ -545,7 +545,7 @@ func TestAppCallApplyGlobalStateDeltas(t *testing.T) {
 	// try illformed delta
 	params.GlobalStateSchema = basics.StateSchema{NumUint: 1}
 	ed.GlobalDelta["bytes"] = basics.ValueDelta{Action: basics.SetBytesAction, Uint: 1}
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 	a.Contains(err.Error(), fmt.Sprintf("GlobalState for app %d would use too much space: store bytes count", appIdx))
 	a.Equal(0, b.put)
@@ -557,7 +557,7 @@ func TestAppCallApplyGlobalStateDeltas(t *testing.T) {
 	br := basics.AccountData{AppParams: map[basics.AppIndex]basics.AppParams{appIdx: params}}
 	cp := basics.AccountData{AppParams: map[basics.AppIndex]basics.AppParams{appIdx: params}}
 	b.balances[creator] = cp
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(1, b.put)
 	pad, ok = b.putBalances[creator]
@@ -589,13 +589,13 @@ func TestAppCallApplyLocalsStateDeltas(t *testing.T) {
 	b.balances = make(map[basics.Address]basics.AccountData)
 	ed.LocalDeltas = make(map[uint64]basics.StateDelta)
 
-	err := ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err := ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
 
 	errIfNotApplied = true
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
@@ -604,16 +604,16 @@ func TestAppCallApplyLocalsStateDeltas(t *testing.T) {
 
 	// non-existing account
 	errIfNotApplied = false
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 
 	errIfNotApplied = true
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 
 	// empty delta
 	ac.Accounts = append(ac.Accounts, sender, sender)
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
@@ -624,14 +624,14 @@ func TestAppCallApplyLocalsStateDeltas(t *testing.T) {
 	ed.LocalDeltas[1] = basics.StateDelta{"bytes": basics.ValueDelta{Action: basics.DeleteAction}}
 	b.balances[sender] = basics.AccountData{}
 	errIfNotApplied = false
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(0, b.put)
 	a.Equal(0, b.putWith)
 	a.Equal(basics.AccountData{}, b.balances[sender])
 	// not opted in
 	errIfNotApplied = true
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 	a.Contains(err.Error(), "acct has not opted in to app")
 	a.Equal(0, b.put)
@@ -646,7 +646,7 @@ func TestAppCallApplyLocalsStateDeltas(t *testing.T) {
 		AppLocalStates: cp,
 	}
 	errIfNotApplied = true
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 	a.Contains(err.Error(), "duplicate LocalState delta")
 	a.Equal(0, b.put)
@@ -663,7 +663,7 @@ func TestAppCallApplyLocalsStateDeltas(t *testing.T) {
 		"bytes": basics.ValueDelta{Action: basics.SetBytesAction, Bytes: "value"},
 	}
 	delete(ed.LocalDeltas, 1)
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.Error(err)
 	a.Contains(err.Error(), "would use too much space")
 	a.Equal(0, b.put)
@@ -678,7 +678,7 @@ func TestAppCallApplyLocalsStateDeltas(t *testing.T) {
 		Schema: basics.StateSchema{NumUint: 1, NumByteSlice: 1},
 	}}
 	b.balances[sender] = basics.AccountData{AppLocalStates: cp}
-	err = ac.applyStateDeltas(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
+	err = ac.applyEvalDelta(ed, params, creator, sender, &b, appIdx, errIfNotApplied)
 	a.NoError(err)
 	a.Equal(1, b.put)
 	a.Equal(0, b.putWith)


### PR DESCRIPTION
Also, disallow zero-length local state deltas. We should never produce them.