### PR TITLE
make kvcow more obviously correct

### DIFF
--- a/data/transactions/logic/kvcow.go
+++ b/data/transactions/logic/kvcow.go
@@ -48,7 +48,8 @@ func (kvc *keyValueCow) read(key string) (value basics.TealValue, ok bool) {
 func (kvc *keyValueCow) write(key string, value basics.TealValue) {
 	// If the value being written is identical to the underlying key/value,
 	// then ensure there is no delta entry for the key.
-	if value == kvc.base[key] {
+	baseValue, ok := kvc.base[key]
+	if ok && value == baseValue {
 		delete(kvc.delta, key)
 	} else {
 		// Otherwise, update the delta with the new value.


### PR DESCRIPTION
I think this is technically fine since an uninitialized `basics.TealValue` is invalid (the type enum starts at 1), but let's make correct behavior not rely on that.