### PR TITLE
Add the opcode plusw.

### DIFF
--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -195,13 +195,17 @@ txn NumAccounts
 txn ApprovalProgram
 txn ClearStateProgram
 txn RekeyTo
+int 0
+int 1
+plusw
 `
 
 // Check that assembly output is stable across time.
 func TestAssemble(t *testing.T) {
 	// UPDATE PROCEDURE:
 	// Run test. It should pass. If test is not passing, do not change this test, fix the assembler first.
-	// Extend this test program text. It is preferrable to append instructions to the end so that the program byte hex is visually similar and also simply extended by some new bytes.
+	// Extend this test program text. Append instructions to the end so that the program byte hex is visually similar and also simply extended by some new bytes,
+	// and so that version-dependent tests pass.
 	// Copy hex string from failing test output into source.
 	// Run test. It should pass.
 	//
@@ -220,7 +224,7 @@ func TestAssemble(t *testing.T) {
 	program, err := AssembleStringWithVersion(bigTestAssembleNonsenseProgram, AssemblerMaxVersion)
 	require.NoError(t, err)
 	// check that compilation is stable over time and we assemble to the same bytes this month that we did last month.
-	expectedBytes, _ := hex.DecodeString("022008b7a60cf8acd19181cf959a12f8acd19181cf951af8acd19181cf15f8acd191810f01020026050212340c68656c6c6f20776f726c6421208dae2087fbba51304eb02b91f656948397a7946390e8cb70fc9ea4d95f92251d024242047465737400320032013202320328292929292a0431003101310231043105310731083109310a310b310c310d310e310f3111311231133114311533000033000133000233000433000533000733000833000933000a33000b33000c33000d33000e33000f3300113300123300133300143300152d2e0102222324252104082209240a220b230c240d250e230f23102311231223132314181b1c2b171615400003290349483403350222231d4a484848482a50512a63222352410003420000432105602105612105270463484821052b62482b642b65484821052b2106662b21056721072b682b6921072105700048482107210571004848361c0037001a0031183119311b311d311e311f3120")
+	expectedBytes, _ := hex.DecodeString("022008b7a60cf8acd19181cf959a12f8acd19181cf951af8acd19181cf15f8acd191810f01020026050212340c68656c6c6f20776f726c6421208dae2087fbba51304eb02b91f656948397a7946390e8cb70fc9ea4d95f92251d024242047465737400320032013202320328292929292a0431003101310231043105310731083109310a310b310c310d310e310f3111311231133114311533000033000133000233000433000533000733000833000933000a33000b33000c33000d33000e33000f3300113300123300133300143300152d2e0102222324252104082209240a220b230c240d250e230f23102311231223132314181b1c2b171615400003290349483403350222231d4a484848482a50512a63222352410003420000432105602105612105270463484821052b62482b642b65484821052b2106662b21056721072b682b6921072105700048482107210571004848361c0037001a0031183119311b311d311e311f3120210721051e")
 	if bytes.Compare(expectedBytes, program) != 0 {
 		// this print is for convenience if the program has been changed. the hex string can be copy pasted back in as a new expected result.
 		t.Log(hex.EncodeToString(program))

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -64,6 +64,7 @@ var opDocList = []stringString{
 	{"^", "A bitwise-xor B"},
 	{"~", "bitwise invert value X"},
 	{"mulw", "A times B out to 128-bit long result as low (top) and high uint64 values on the stack"},
+	{"plusw", "A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack"},
 	{"intcblock", "load block of uint64 constants"},
 	{"intc", "push value from uint64 constants to stack by index into constants"},
 	{"intc_0", "push constant 0 from intcblock to stack"},
@@ -162,6 +163,7 @@ var opDocExtraList = []stringString{
 	{"intcblock", "`intcblock` loads following program bytes into an array of integer constants in the evaluator. These integer constants can be referred to by `intc` and `intc_*` which will push the value onto the stack. Subsequent calls to `intcblock` reset and replace the integer constants available to the script."},
 	{"bytecblock", "`bytecblock` loads the following program bytes into an array of byte string constants in the evaluator. These constants can be referred to by `bytec` and `bytec_*` which will push the value onto the stack. Subsequent calls to `bytecblock` reset and replace the bytes constants available to the script."},
 	{"*", "Overflow is an error condition which halts execution and fails the transaction. Full precision is available from `mulw`."},
+	{"+", "Overflow is an error condition which halts execution and fails the transaction. Full precision is available from `plusw`."},
 	{"txn", "FirstValidTime causes the program to fail. The field is reserved for future use."},
 	{"gtxn", "for notes on transaction fields available, see `txn`. If this transaction is _i_ in the group, `gtxn i field` is equivalent to `txn field`."},
 	{"btoi", "`btoi` panics if the input is longer than 8 bytes."},
@@ -197,7 +199,7 @@ type OpGroup struct {
 
 // OpGroupList is groupings of ops for documentation purposes.
 var OpGroupList = []OpGroup{
-	{"Arithmetic", []string{"sha256", "keccak256", "sha512_256", "ed25519verify", "+", "-", "/", "*", "<", ">", "<=", ">=", "&&", "||", "==", "!=", "!", "len", "itob", "btoi", "%", "|", "&", "^", "~", "mulw", "concat", "substring", "substring3"}},
+	{"Arithmetic", []string{"sha256", "keccak256", "sha512_256", "ed25519verify", "+", "-", "/", "*", "<", ">", "<=", ">=", "&&", "||", "==", "!=", "!", "len", "itob", "btoi", "%", "|", "&", "^", "~", "mulw", "plusw", "concat", "substring", "substring3"}},
 	{"Loading Values", []string{"intcblock", "intc", "intc_0", "intc_1", "intc_2", "intc_3", "bytecblock", "bytec", "bytec_0", "bytec_1", "bytec_2", "bytec_3", "arg", "arg_0", "arg_1", "arg_2", "arg_3", "txn", "gtxn", "txna", "gtxna", "global", "load", "store"}},
 	{"Flow Control", []string{"err", "bnz", "bz", "b", "return", "pop", "dup", "dup2"}},
 	{"State Access", []string{"balance", "app_opted_in", "app_local_get", "app_local_get_ex", "app_global_get", "app_global_get_ex", "app_local_put", "app_global_put", "app_local_del", "app_global_del", "asset_holding_get", "asset_params_get"}},

--- a/data/transactions/logic/doc_test.go
+++ b/data/transactions/logic/doc_test.go
@@ -80,7 +80,7 @@ func TestOpImmediateNote(t *testing.T) {
 func TestOpDocExtra(t *testing.T) {
 	xd := OpDocExtra("bnz")
 	require.NotEmpty(t, xd)
-	xd = OpDocExtra("+")
+	xd = OpDocExtra("-")
 	require.Empty(t, xd)
 }
 

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -682,6 +682,22 @@ func opPlus(cx *evalContext) {
 	cx.stack = cx.stack[:last]
 }
 
+func opPluswImpl(x, y uint64) (carry uint64, sum uint64) {
+	sum = x + y
+	if sum < x {
+		carry = 1
+	}
+	return
+}
+
+func opPlusw(cx *evalContext) {
+	last := len(cx.stack) - 1
+	prev := last - 1
+	carry, sum := opPluswImpl(cx.stack[prev].Uint, cx.stack[last].Uint)
+	cx.stack[prev].Uint = carry
+	cx.stack[last].Uint = sum
+}
+
 func opMinus(cx *evalContext) {
 	last := len(cx.stack) - 1
 	prev := last - 1

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -678,6 +678,25 @@ int 1                   // ret 1
 	}
 }
 
+func TestPluswImpl(t *testing.T) {
+	t.Parallel()
+	carry, sum := opPluswImpl(1, 2)
+	require.Equal(t, uint64(0), carry)
+	require.Equal(t, uint64(3), sum)
+
+	carry, sum = opPluswImpl(0xFFFFFFFFFFFFFFFD, 0x45)
+	require.Equal(t, uint64(1), carry)
+	require.Equal(t, uint64(0x42), sum)
+
+	carry, sum = opPluswImpl(0, 0)
+	require.Equal(t, uint64(0), carry)
+	require.Equal(t, uint64(0), sum)
+
+	carry, sum = opPluswImpl((1<<64)-1, (1<<64)-1)
+	require.Equal(t, uint64(1), carry)
+	require.Equal(t, uint64((1<<64)-2), sum)
+}
+
 func TestPlusw(t *testing.T) {
 	t.Parallel()
 	// add two numbers, ensure sum is 0x42 and carry is 0x1
@@ -686,12 +705,12 @@ func TestPlusw(t *testing.T) {
 			program, err := AssembleStringWithVersion(`int 0xFFFFFFFFFFFFFFFF
 int 0x43
 plusw
-int 0x42  // compare low (top of the stack)
+int 0x42  // compare sum (top of the stack)
 ==
 bnz continue
 err
 continue:
-int 1                   // compare high
+int 1                   // compare carry
 ==
 bnz done
 err

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -97,6 +97,7 @@ var OpSpecs = []OpSpec{
 	{0x1b, "^", opBitXor, asmDefault, disDefault, twoInts, oneInt, 1, modeAny, opSizeDefault},
 	{0x1c, "~", opBitNot, asmDefault, disDefault, oneInt, oneInt, 1, modeAny, opSizeDefault},
 	{0x1d, "mulw", opMulw, asmDefault, disDefault, twoInts, twoInts, 1, modeAny, opSizeDefault},
+	{0x1e, "plusw", opPlusw, asmDefault, disDefault, twoInts, twoInts, 2, modeAny, opSizeDefault},
 
 	{0x20, "intcblock", opIntConstBlock, assembleIntCBlock, disIntcblock, nil, nil, 1, modeAny, opSize{1, 0, checkIntConstBlock}},
 	{0x21, "intc", opIntConstLoad, assembleIntC, disIntc, nil, oneInt, 1, modeAny, opSize{1, 2, nil}},

--- a/data/transactions/logic/opcodes_test.go
+++ b/data/transactions/logic/opcodes_test.go
@@ -144,7 +144,7 @@ func TestOpcodesVersioningV2(t *testing.T) {
 	require.Equal(t, cntv2, len(opsByName[2]))
 
 	// hardcode and ensure amount of new v2 opcodes
-	newOpcodes := 21
+	newOpcodes := 22
 	overwritten := 5 // sha256, keccak256, sha512_256, txn, gtxn
 	require.Equal(t, newOpcodes+overwritten, cntAdded)
 


### PR DESCRIPTION
plusw is an analog of the mulw opcode.

It adds two integers and pushes the low integer component of the sum
to the top of the stack and the carry bit immediately underneath.

plusw makes it easier to compare two 128-bit sums.

In conjunction with mulw, plusw is useful for verifying that 128-bit
division was performed correctly.

A future change could add plusw3, which would facilitate
implementation of bignum arithmetic.

## Test Plan

Unit tests added to cover new opcode.
