### PR TITLE
Add back critical `RekeyTo` check

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -50,11 +50,6 @@ const EvalMaxScratchSize = 255
 // MaxStringSize is the limit of byte strings created by `concat`
 const MaxStringSize = 4096
 
-// rekeyingEnabledVersion is the version of TEAL where RekeyTo functionality
-// was enabled. This is important to remember so that old TEAL accounts cannot
-// be maliciously or accidentally rekeyed.
-const rekeyingEnabledVersion = 2
-
 // stackValue is the type for the operand stack.
 // Each stackValue is either a valid []byte value or a uint64 value.
 // If (.Bytes != nil) the stackValue is a []byte value, otherwise uint64 value.

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -369,14 +369,6 @@ func eval(program []byte, cx *evalContext) (pass bool, err error) {
 		return false, cx.err
 	}
 
-	// A transaction may not have a nonzero RekeyTo field set before TEAL
-	// v2, otherwise TEAL v0 or v1 accounts could be rekeyed by an anyone
-	// who could ordinarily spend from them.
-	if version < rekeyingEnabledVersion && !cx.EvalParams.Txn.Txn.RekeyTo.IsZero() {
-		cx.err = fmt.Errorf("program version %d doesn't allow transactions with nonzero RekeyTo field", version)
-		return false, cx.err
-	}
-
 	// TODO: if EvalMaxVersion > version, ensure that inaccessible
 	// fields as of the program's version are zero or other
 	// default value so that no one is hiding unexpected
@@ -386,6 +378,11 @@ func eval(program []byte, cx *evalContext) (pass bool, err error) {
 	cx.pc = vlen
 	cx.stack = make([]stackValue, 0, 10)
 	cx.program = program
+
+	err = cx.checkRekeyAllowed()
+	if err != nil {
+		return
+	}
 
 	if cx.Debugger != nil {
 		cx.debugState = makeDebugState(cx)
@@ -477,10 +474,17 @@ func check(program []byte, params EvalParams) (cost int, err error) {
 		err = fmt.Errorf("program version %d greater than protocol supported version %d", version, params.Proto.LogicSigVersion)
 		return
 	}
+
 	cx.version = version
 	cx.pc = vlen
 	cx.EvalParams = params
 	cx.program = program
+
+	err = cx.checkRekeyAllowed()
+	if err != nil {
+		return
+	}
+
 	for (cx.err == nil) && (cx.pc < len(cx.program)) {
 		prevpc := cx.pc
 		cost += cx.checkStep()
@@ -494,6 +498,16 @@ func check(program []byte, params EvalParams) (cost int, err error) {
 		return
 	}
 	return
+}
+
+func (cx *evalContext) checkRekeyAllowed() error {
+	// A transaction may not have a nonzero RekeyTo field set before TEAL
+	// v2, otherwise TEAL v0 or v1 accounts could be rekeyed by an anyone
+	// who could ordinarily spend from them.
+	if cx.version < rekeyingEnabledVersion && !cx.EvalParams.Txn.Txn.RekeyTo.IsZero() {
+		return fmt.Errorf("program version %d doesn't allow transactions with nonzero RekeyTo field", cx.version)
+	}
+	return nil
 }
 
 func opCompat(expected, got StackType) bool {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3713,3 +3713,27 @@ func TestAllowedOpcodesV2(t *testing.T) {
 	}
 	require.Equal(t, len(tests), cnt)
 }
+
+func TestRekeyFailsOnOldVersion(t *testing.T) {
+	t.Parallel()
+	for v := uint64(0); v < rekeyingEnabledVersion; v++ {
+		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			program, err := AssembleStringWithVersion(`int 1`, v)
+			require.NoError(t, err)
+			var txn transactions.SignedTxn
+			txn.Lsig.Logic = program
+			txn.Txn.RekeyTo = basics.Address{1, 2, 3, 4}
+			sb := strings.Builder{}
+			proto := defaultEvalProto()
+			ep := defaultEvalParams(&sb, &txn)
+			ep.Proto = &proto
+			_, err = Check(program, ep)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "nonzero RekeyTo field")
+			pass, err := Eval(program, ep)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "nonzero RekeyTo field")
+			require.False(t, pass)
+		})
+	}
+}

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -23,6 +23,11 @@ import (
 // LogicVersion defines default assembler and max eval versions
 const LogicVersion = 2
 
+// rekeyingEnabledVersion is the version of TEAL where RekeyTo functionality
+// was enabled. This is important to remember so that old TEAL accounts cannot
+// be maliciously or accidentally rekeyed.
+const rekeyingEnabledVersion = 2
+
 // opSize records the length in bytes for an op that is constant-length but not length 1
 type opSize struct {
 	cost      int


### PR DESCRIPTION
Even though the getter for the `RekeyTo` field is versioned, we must still ensure that this field is empty for old TEAL versions. Otherwise old TEAL accounts could be rekeyed maliciously. (Thanks @algoradam!)