### PR TITLE
TEAL Debugger: add consistency in bytes encoding

### DIFF
--- a/cmd/tealdbg/debugger.go
+++ b/cmd/tealdbg/debugger.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -299,7 +300,13 @@ func (s *session) GetStates(changes *logic.AppStateChage) appState {
 			case basics.SetUintAction:
 				tkv[key] = basics.TealValue{Type: basics.TealUintType, Uint: delta.Uint}
 			case basics.SetBytesAction:
-				tkv[key] = basics.TealValue{Type: basics.TealBytesType, Bytes: delta.Bytes}
+				data, err := base64.StdEncoding.DecodeString(delta.Bytes)
+				if err != nil {
+					data = []byte(delta.Bytes)
+				}
+				tkv[key] = basics.TealValue{
+					Type: basics.TealBytesType, Bytes: string(data),
+				}
 			case basics.DeleteAction:
 				delete(tkv, key)
 			}

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -17,6 +17,7 @@
 package v2
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -498,12 +499,13 @@ func StateDeltaToStateDelta(sd basics.StateDelta) *generated.StateDelta {
 
 	gsd := make(generated.StateDelta, 0, len(sd))
 	for k, v := range sd {
+		bytes := base64.StdEncoding.EncodeToString([]byte(v.Bytes))
 		gsd = append(gsd, generated.EvalDeltaKeyValue{
 			Key: k,
 			Value: generated.EvalDelta{
 				Action: uint64(v.Action),
 				Uint:   &v.Uint,
-				Bytes:  &v.Bytes,
+				Bytes:  &bytes,
 			},
 		})
 	}

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -527,7 +527,7 @@ func TestDryrunLocal1(t *testing.T) {
 				if ld.Key == "foo" {
 					valueFound = true
 					assert.Equal(t, ld.Value.Action, uint64(basics.SetBytesAction))
-					assert.Equal(t, *ld.Value.Bytes, "bar")
+					assert.Equal(t, *ld.Value.Bytes, "YmFy") // bar
 
 				}
 			}
@@ -604,7 +604,7 @@ func TestDryrunLocal1A(t *testing.T) {
 				if ld.Key == "foo" {
 					valueFound = true
 					assert.Equal(t, ld.Value.Action, uint64(basics.SetBytesAction))
-					assert.Equal(t, *ld.Value.Bytes, "bar")
+					assert.Equal(t, *ld.Value.Bytes, "YmFy") // bar
 
 				}
 			}

--- a/data/transactions/logic/debugger.go
+++ b/data/transactions/logic/debugger.go
@@ -185,6 +185,14 @@ func stackValueToTealValue(sv *stackValue) basics.TealValue {
 	}
 }
 
+func valueDeltaToValueDelta(vd *basics.ValueDelta) basics.ValueDelta {
+	return basics.ValueDelta{
+		Action: vd.Action,
+		Bytes:  base64.StdEncoding.EncodeToString([]byte(vd.Bytes)),
+		Uint:   vd.Uint,
+	}
+}
+
 func (cx *evalContext) refreshDebugState() *DebugState {
 	ds := &cx.debugState
 
@@ -211,13 +219,13 @@ func (cx *evalContext) refreshDebugState() *DebugState {
 	if (cx.runModeFlags & runModeApplication) != 0 {
 		if cx.globalStateCow != nil {
 			for k, v := range cx.globalStateCow.delta {
-				ds.GlobalStateChanges[k] = v
+				ds.GlobalStateChanges[k] = valueDeltaToValueDelta(&v)
 			}
 		}
 		for addr, cow := range cx.localStateCows {
 			delta := make(basics.StateDelta, len(cow.cow.delta))
 			for k, v := range cow.cow.delta {
-				delta[k] = v
+				delta[k] = valueDeltaToValueDelta(&v)
 			}
 			ds.LocalStateChanges[addr] = delta
 		}


### PR DESCRIPTION
* Found out stack and scratch values were base64-encoded but eval delta not
* Now all are encoded
